### PR TITLE
Multi-instance and multi-core

### DIFF
--- a/running-solr-with-maven/pom.xml
+++ b/running-solr-with-maven/pom.xml
@@ -136,30 +136,14 @@
                                         <include>solr.xml</include>
                                     </includes>
                                 </resource>
-                                <!-- Copies configuration files -->
+                                <!--
+                                     Copies configuration files (/), language specific configuration (/lang),
+                                     Velocity macros and other files (/velocity), XSL style sheets (/xslt)
+                                -->
                                 <resource>
                                     <directory>${project.basedir}/src/main/config</directory>
                                     <targetPath>${solr.solr.home}/${solr.default.core.directory}/conf</targetPath>
-                                    <excludes>
-                                        <exclude>lang</exclude>
-                                        <exclude>velocity</exclude>
-                                        <exclude>xslt</exclude>
-                                    </excludes>
-                                </resource>
-                                <!-- Copies language specific configuration files -->
-                                <resource>
-                                    <directory>${project.basedir}/src/main/config/lang</directory>
-                                    <targetPath>${solr.solr.home}/${solr.default.core.directory}/conf/lang</targetPath>
-                                </resource>
-                                <!-- Copy Velocity macros and other files -->
-                                <resource>
-                                    <directory>${project.basedir}/src/main/config/velocity</directory>
-                                    <targetPath>${solr.solr.home}/${solr.default.core.directory}/conf/velocity</targetPath>
-                                </resource>
-                                <!-- Copy XSL style sheets -->
-                                <resource>
-                                    <directory>${project.basedir}/src/main/config/xslt</directory>
-                                    <targetPath>${solr.solr.home}/${solr.default.core.directory}/conf/xslt</targetPath>
+                                    <preservePath>true</preservePath>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
Hi Petri,

Could you please consider merging my changes with your code? I believe these commits are beneficial because:
- setting TCP ports as Maven variables allows to run multiple Solr instances on one machine (by overwriting default ports from command line).
- pom.xml simplification (i.e. preservePath option) makes it easier to implement multi-core solution. Since Solr 4.4 cores can be auto-detected (http://wiki.apache.org/solr/Core%20Discovery%20%284.4%20and%20beyond%29). This approach will allow (after some other changes) to have one "template" multi-core directory.

Kind regards,

Tom
